### PR TITLE
Discount coupons initial

### DIFF
--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -4,6 +4,7 @@ from plone.app.layout.viewlets import common as base
 from datetime import datetime, timedelta
 from zope.globalrequest import getRequest
 
+
 def get_existing_coupon_code(self):
     request = getRequest()
     coupon = request.form.get('couponcode')
@@ -15,7 +16,7 @@ def get_existing_coupon_code(self):
 
 class CouponViewlet(base.ViewletBase):
     """ This viewlet is used to provide an input field for the coupon code. The
-    viewlet checks for the code and stores it into a cookie. 
+    viewlet checks for the code and stores it into a cookie.
 
     TODO: Make coupon code validation and return the information to the user
     """
@@ -25,9 +26,8 @@ class CouponViewlet(base.ViewletBase):
         return ""
 
     def available(self):
-        """Return whether viewlet should be rendered or not. So far, we show 
-        the viewlet everywhere. 
-        
+        """Return whether viewlet should be rendered or not. So far, we show
+        the viewlet everywhere.
         """
         return True
 

--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -1,2 +1,42 @@
 # -*- coding: utf-8 -*-
 #
+from plone.app.layout.viewlets import common as base
+from datetime import datetime, date, time, timedelta
+from bda.plone.discount.calculator import RuleAcquierer
+class CouponViewlet(base.ViewletBase):
+
+    def render(self):
+        if self.available():
+            return super(CouponViewlet, self).render()
+        return ""
+
+    def available(self):
+        """Return whether viewlet should be rendered or not.
+
+        If we are on one of the checkout views return True, otherwise
+        false.
+        """
+        return True
+
+    def update(self):
+
+        # Check for user input
+        coupon_code = self.request.form.get('couponcode')
+        # Check whether cookie exists
+        discount_cookie = self.request.get('discount_couponcode')
+        
+        # If coupon_code is provided by a user, set a cookie even if it already 
+        # exists
+        if coupon_code:
+            expiry_date = (datetime.now()+timedelta(days=1)).strftime('%c')
+            self.request.response.setCookie('discount_couponcode', coupon_code, expires=expiry_date, path='/')
+        elif discount_cookie and coupon_code == '':
+            # Expire cookie in case if empty form was submitted, but not if site was reloaded
+            self.request.response.expireCookie('discount_couponcode', path='/')
+            
+    def existing_coupon_code(self):
+        coupon = self.request.form.get('couponcode')
+        # If no form has been submitted, check for coupon in the cookie
+        if coupon == None:
+            coupon = self.request.get('discount_couponcode')
+        return coupon

--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 from plone.app.layout.viewlets import common as base
-from datetime import datetime, date, time, timedelta
-from bda.plone.discount.calculator import RuleAcquierer
+from datetime import datetime, timedelta
+
+
 class CouponViewlet(base.ViewletBase):
 
     def render(self):
@@ -19,28 +20,28 @@ class CouponViewlet(base.ViewletBase):
         return True
 
     def update(self):
-
         # Check for user input
         coupon_code = self.request.form.get('couponcode')
         # Check whether cookie exists
         discount_cookie = self.request.get('discount_couponcode')
-        
+
         url = self.request.HTTP_REFERER
-        # If coupon_code is provided by a user, set a cookie even if it already 
+        # If coupon_code is provided by a user, set a cookie even if it already
         # exists
         if coupon_code:
             expiry_date = (datetime.now()+timedelta(days=1)).strftime('%c')
-            self.request.response.setCookie('discount_couponcode', coupon_code, expires=expiry_date, path='/')
+            self.request.response.setCookie('discount_couponcode', coupon_code,
+                                            expires=expiry_date, path='/')
             self.request.response.redirect(url)
         elif discount_cookie and coupon_code == '':
-            # Expire cookie in case if empty form was submitted, but not if site was reloaded
+            # Expire cookie in case if empty form was submitted, but not if
+            # site was reloaded
             self.request.response.expireCookie('discount_couponcode', path='/')
             self.request.response.redirect(url)
 
-            
     def existing_coupon_code(self):
         coupon = self.request.form.get('couponcode')
         # If no form has been submitted, check for coupon in the cookie
-        if coupon == None:
+        if coupon is None:
             coupon = self.request.get('discount_couponcode')
         return coupon

--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -5,17 +5,20 @@ from datetime import datetime, timedelta
 
 
 class CouponViewlet(base.ViewletBase):
+    """ This viewlet is used to provide an input field for the coupon code. The
+    viewlet checks for the code and stores it into a cookie. 
 
+    TODO: Make coupon code validation and return the information to the user
+    """
     def render(self):
         if self.available():
             return super(CouponViewlet, self).render()
         return ""
 
     def available(self):
-        """Return whether viewlet should be rendered or not.
-
-        If we are on one of the checkout views return True, otherwise
-        false.
+        """Return whether viewlet should be rendered or not. So far, we show 
+        the viewlet everywhere. 
+        
         """
         return True
 
@@ -35,7 +38,8 @@ class CouponViewlet(base.ViewletBase):
             self.request.response.redirect(url)
         elif discount_cookie and coupon_code == '':
             # Expire cookie in case if empty form was submitted, but not if
-            # site was reloaded
+            # no action has been submitted by a user and the coupon_code is
+            # therefore None
             self.request.response.expireCookie('discount_couponcode', path='/')
             self.request.response.redirect(url)
 

--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -25,14 +25,18 @@ class CouponViewlet(base.ViewletBase):
         # Check whether cookie exists
         discount_cookie = self.request.get('discount_couponcode')
         
+        url = self.request.HTTP_REFERER
         # If coupon_code is provided by a user, set a cookie even if it already 
         # exists
         if coupon_code:
             expiry_date = (datetime.now()+timedelta(days=1)).strftime('%c')
             self.request.response.setCookie('discount_couponcode', coupon_code, expires=expiry_date, path='/')
+            self.request.response.redirect(url)
         elif discount_cookie and coupon_code == '':
             # Expire cookie in case if empty form was submitted, but not if site was reloaded
             self.request.response.expireCookie('discount_couponcode', path='/')
+            self.request.response.redirect(url)
+
             
     def existing_coupon_code(self):
         coupon = self.request.form.get('couponcode')

--- a/src/bda/plone/discount/browser/__init__.py
+++ b/src/bda/plone/discount/browser/__init__.py
@@ -2,6 +2,15 @@
 #
 from plone.app.layout.viewlets import common as base
 from datetime import datetime, timedelta
+from zope.globalrequest import getRequest
+
+def get_existing_coupon_code(self):
+    request = getRequest()
+    coupon = request.form.get('couponcode')
+    # If no form has been submitted, check for coupon in the cookie
+    if coupon is None:
+        coupon = request.get('discount_couponcode')
+    return coupon
 
 
 class CouponViewlet(base.ViewletBase):
@@ -44,8 +53,4 @@ class CouponViewlet(base.ViewletBase):
             self.request.response.redirect(url)
 
     def existing_coupon_code(self):
-        coupon = self.request.form.get('couponcode')
-        # If no form has been submitted, check for coupon in the cookie
-        if coupon is None:
-            coupon = self.request.get('discount_couponcode')
-        return coupon
+        return get_existing_coupon_code(self)

--- a/src/bda/plone/discount/browser/configure.zcml
+++ b/src/bda/plone/discount/browser/configure.zcml
@@ -120,6 +120,20 @@
     permission="bda.plone.discount.ManageDiscount"
     layer="..interfaces.IDiscountExtensionLayer" />
 
+  <browser:page
+    for="..interfaces.IDiscountSettingsEnabled"
+    name="coupon_cart_item_discount_form"
+    class=".forms.CouponCartItemDiscountForm"
+    permission="bda.plone.discount.ManageDiscount"
+    layer="..interfaces.IDiscountExtensionLayer" />
+
+  <browser:page
+    for="zope.component.interfaces.ISite"
+    name="coupon_cart_item_discount_form"
+    class=".forms.CouponCartItemDiscountForm"
+    permission="bda.plone.discount.ManageDiscount"
+    layer="..interfaces.IDiscountExtensionLayer" />
+
   <!-- cart discount forms -->
   <browser:page
     for="zope.component.interfaces.ISite"
@@ -172,6 +186,15 @@
     zcml:condition="have plone-5"
     name="bda.plone.discount.css.map"
     file="discount_p5.css.map"
+    layer="..interfaces.IDiscountExtensionLayer" />
+
+  <!-- viewlets -->
+  <browser:viewlet
+    name="bda.plone.discount.coupon"
+    class=".CouponViewlet"
+    template="coupon_viewlet.pt"
+    manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
+    permission="zope2.View"
     layer="..interfaces.IDiscountExtensionLayer" />
 
 </configure>

--- a/src/bda/plone/discount/browser/configure.zcml
+++ b/src/bda/plone/discount/browser/configure.zcml
@@ -156,6 +156,13 @@
     permission="bda.plone.discount.ManageDiscount"
     layer="..interfaces.IDiscountExtensionLayer" />
 
+ <browser:page
+    for="zope.component.interfaces.ISite"
+    name="coupon_cart_discount_form"
+    class=".forms.CouponCartDiscountForm"
+    permission="bda.plone.discount.ManageDiscount"
+    layer="..interfaces.IDiscountExtensionLayer" />
+
   <!-- generic resources -->
   <browser:resource
     name="bda.plone.discount.js"

--- a/src/bda/plone/discount/browser/coupon_header.pt
+++ b/src/bda/plone/discount/browser/coupon_header.pt
@@ -1,0 +1,52 @@
+<tal:block i18n:domain="bda.plone.discount">
+
+  <div id="field-discount_form-discount-label_kind"
+       class="kind form_header">
+    <label for="input-discount_form-discount-label_kind"
+           class="kind form_header"
+           i18n:translate="discount_form_label_kind">Kind</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_block"
+       class="block form_header">
+    <label for="input-discount_form-discount-label_block"
+           class="block form_header"
+           i18n:translate="discount_form_label_block">Block parental</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_value"
+       class="value form_header">
+    <label for="input-discount_form-discount-label_value"
+           class="value form_header"
+           i18n:translate="discount_form_label_value">Value</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_threshold"
+       class="threshold form_header">
+    <label for="input-discount_form-discount-label_threshold"
+           class="threshold form_header"
+           i18n:translate="discount_form_label_threshold">Threshold</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_valid_from"
+       class="valid_from form_header">
+    <label for="input-discount_form-discount-label_valid_from"
+           class="valid_from form_header"
+           i18n:translate="discount_form_label_valid_from">Valid From</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_valid_to"
+       class="valid_to form_header">
+    <label for="input-discount_form-discount-label_valid_to"
+           class="valid_to form_header"
+           i18n:translate="discount_form_label_valid_to">Valid To</label>
+  </div>
+
+  <div id="field-discount_form-discount-label_for"
+       class="for form_header">
+    <label for="input-discount_form-discount-label_for"
+           class="for form_header"
+           i18n:translate="discount_form_label_coupon">Coupon</label>
+  </div>
+
+</tal:block>

--- a/src/bda/plone/discount/browser/coupon_viewlet.pt
+++ b/src/bda/plone/discount/browser/coupon_viewlet.pt
@@ -1,8 +1,8 @@
 <tal:block i18n:domain="bda.plone.discount">
-	<div tal:define="couponcode view/existing_coupon_code">
-  		<form action="#">
-  			<span i18n:translate="">Coupon code:</span>
-    		<input type="text" name="couponcode" value="${couponcode}">
+	<div class="coupon_discount_viewlet" tal:define="couponcode view/existing_coupon_code">
+  		<form action="">
+  			<!--span i18n:translate="">Coupon/Voucher:</span-->
+    		<input type="text" name="couponcode" value="${couponcode}" placeholder="Coupon code">
     		<input type="submit" value="Submit">
   		</form> 
 	</div>

--- a/src/bda/plone/discount/browser/coupon_viewlet.pt
+++ b/src/bda/plone/discount/browser/coupon_viewlet.pt
@@ -1,0 +1,9 @@
+<tal:block i18n:domain="bda.plone.discount">
+	<div tal:define="couponcode view/existing_coupon_code">
+  		<form action="#">
+  			<span i18n:translate="">Coupon code:</span>
+    		<input type="text" name="couponcode" value="${couponcode}">
+    		<input type="submit" value="Submit">
+  		</form> 
+	</div>
+</tal:block>

--- a/src/bda/plone/discount/browser/coupon_viewlet.pt
+++ b/src/bda/plone/discount/browser/coupon_viewlet.pt
@@ -1,11 +1,11 @@
 <tal:block i18n:domain="bda.plone.discount">
   <div class="coupon_discount_viewlet" 
-  	   tal:define="couponcode view/existing_coupon_code">
-  	<form action="">
+       tal:define="couponcode view/existing_coupon_code">
+    <form action="">
       <input type="text" name="couponcode" 
       		 value="${couponcode}"
     		 placeholder="Coupon code">
       <input type="submit" value="Submit">
-  	</form> 
+    </form> 
   </div>
 </tal:block>

--- a/src/bda/plone/discount/browser/coupon_viewlet.pt
+++ b/src/bda/plone/discount/browser/coupon_viewlet.pt
@@ -1,9 +1,11 @@
 <tal:block i18n:domain="bda.plone.discount">
-	<div class="coupon_discount_viewlet" tal:define="couponcode view/existing_coupon_code">
-  		<form action="">
-  			<!--span i18n:translate="">Coupon/Voucher:</span-->
-    		<input type="text" name="couponcode" value="${couponcode}" placeholder="Coupon code">
-    		<input type="submit" value="Submit">
-  		</form> 
-	</div>
+  <div class="coupon_discount_viewlet" 
+  	   tal:define="couponcode view/existing_coupon_code">
+  	<form action="">
+      <input type="text" name="couponcode" 
+      		 value="${couponcode}"
+    		 placeholder="Coupon code">
+      <input type="submit" value="Submit">
+  	</form> 
+  </div>
 </tal:block>

--- a/src/bda/plone/discount/browser/discount_p4.css
+++ b/src/bda/plone/discount/browser/discount_p4.css
@@ -91,3 +91,6 @@ div.array_field.valid_to .timepicker {
 .array_field.value {
     padding: 0 0.25em;
 }
+.array_actions a {
+    float: none !important;
+}

--- a/src/bda/plone/discount/browser/forms.py
+++ b/src/bda/plone/discount/browser/forms.py
@@ -7,12 +7,14 @@ from bda.plone.discount.interfaces import CEILING_DATETIME
 from bda.plone.discount.interfaces import FLOOR_DATETIME
 from bda.plone.discount.interfaces import FOR_GROUP
 from bda.plone.discount.interfaces import FOR_USER
+from bda.plone.discount.interfaces import FOR_COUPON
 from bda.plone.discount.interfaces import ICartDiscountSettings
 from bda.plone.discount.interfaces import ICartItemDiscountSettings
 from bda.plone.discount.interfaces import IGroupCartDiscountSettings
 from bda.plone.discount.interfaces import IGroupCartItemDiscountSettings
 from bda.plone.discount.interfaces import IUserCartDiscountSettings
 from bda.plone.discount.interfaces import IUserCartItemDiscountSettings
+from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
 from bda.plone.discount.interfaces import KIND_ABSOLUTE
 from bda.plone.discount.interfaces import KIND_OFF
 from bda.plone.discount.interfaces import KIND_PERCENT
@@ -154,10 +156,13 @@ class DiscountFormBase(YAMLBaseForm):
         for rule in extracted:
             user = ''
             group = ''
+            coupon = ''
             if self.for_attribute == FOR_USER:
                 user = rule['for'] and rule['for'] or user
             if self.for_attribute == FOR_GROUP:
                 group = rule['for'] and rule['for'] or group
+            if self.for_attribute == FOR_COUPON:
+                coupon = rule['for'] and rule['for'] or coupon
             settings.add_rule(self.context,
                               index,
                               rule['kind'],
@@ -167,7 +172,8 @@ class DiscountFormBase(YAMLBaseForm):
                               rule['valid_from'],
                               rule['valid_to'],
                               user=user,
-                              group=group)
+                              group=group,
+                              coupon=coupon)
             index += 1
 
     def next(self, request):
@@ -206,6 +212,15 @@ class GroupDiscountFormBase(DiscountFormBase):
     for_callback = 'javascript:discount_form.autocomplete_group'
     for_mode = 'edit'
 
+class CouponDiscountFormBase(DiscountFormBase):
+    header_template = 'coupon_header.pt'
+    for_attribute = FOR_COUPON
+    for_label = _('discount_form_label_coupon', default=u'Coupon')
+    for_required = _('discount_form_coupon_required',
+                     default=u'Coupon is required')
+#    for_callback = 'javascript:discount_form.autocomplete_group'
+    for_mode = 'edit'
+
 
 class CartItemDiscountForm(DiscountFormBase):
     settings_iface = ICartItemDiscountSettings
@@ -220,6 +235,11 @@ class UserCartItemDiscountForm(UserDiscountFormBase, CartItemDiscountForm):
 class GroupCartItemDiscountForm(GroupDiscountFormBase, CartItemDiscountForm):
     settings_iface = IGroupCartItemDiscountSettings
     action_resource = 'group_cart_item_discount_form'
+
+class CouponCartItemDiscountForm(CouponDiscountFormBase, CartItemDiscountForm):
+    settings_iface = ICouponCartItemDiscountSettings
+    action_resource = 'coupon_cart_item_discount_form'
+
 
 
 class CartDiscountForm(DiscountFormBase):

--- a/src/bda/plone/discount/browser/forms.py
+++ b/src/bda/plone/discount/browser/forms.py
@@ -15,6 +15,7 @@ from bda.plone.discount.interfaces import IGroupCartItemDiscountSettings
 from bda.plone.discount.interfaces import IUserCartDiscountSettings
 from bda.plone.discount.interfaces import IUserCartItemDiscountSettings
 from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
+from bda.plone.discount.interfaces import ICouponCartDiscountSettings
 from bda.plone.discount.interfaces import KIND_ABSOLUTE
 from bda.plone.discount.interfaces import KIND_OFF
 from bda.plone.discount.interfaces import KIND_PERCENT
@@ -218,7 +219,7 @@ class CouponDiscountFormBase(DiscountFormBase):
     for_label = _('discount_form_label_coupon', default=u'Coupon')
     for_required = _('discount_form_coupon_required',
                      default=u'Coupon is required')
-#    for_callback = 'javascript:discount_form.autocomplete_group'
+    for_callback = ''
     for_mode = 'edit'
 
 
@@ -236,10 +237,10 @@ class GroupCartItemDiscountForm(GroupDiscountFormBase, CartItemDiscountForm):
     settings_iface = IGroupCartItemDiscountSettings
     action_resource = 'group_cart_item_discount_form'
 
+
 class CouponCartItemDiscountForm(CouponDiscountFormBase, CartItemDiscountForm):
     settings_iface = ICouponCartItemDiscountSettings
     action_resource = 'coupon_cart_item_discount_form'
-
 
 
 class CartDiscountForm(DiscountFormBase):
@@ -258,6 +259,13 @@ class UserCartDiscountForm(UserDiscountFormBase, CartDiscountForm):
     action_resource = 'user_cart_discount_form'
 
 
+class CouponCartDiscountForm(CouponDiscountFormBase, CartDiscountForm):
+    settings_iface = ICouponCartDiscountSettings
+    action_resource = 'coupon_cart_discount_form'
+
+
 class GroupCartDiscountForm(GroupDiscountFormBase, CartDiscountForm):
     settings_iface = IGroupCartDiscountSettings
     action_resource = 'group_cart_discount_form'
+
+

--- a/src/bda/plone/discount/browser/forms.py
+++ b/src/bda/plone/discount/browser/forms.py
@@ -213,6 +213,7 @@ class GroupDiscountFormBase(DiscountFormBase):
     for_callback = 'javascript:discount_form.autocomplete_group'
     for_mode = 'edit'
 
+
 class CouponDiscountFormBase(DiscountFormBase):
     header_template = 'coupon_header.pt'
     for_attribute = FOR_COUPON
@@ -254,6 +255,7 @@ class CartDiscountForm(DiscountFormBase):
             (KIND_OFF, _('off', _('off', default=u'Off'))),
         ]
 
+
 class UserCartDiscountForm(UserDiscountFormBase, CartDiscountForm):
     settings_iface = IUserCartDiscountSettings
     action_resource = 'user_cart_discount_form'
@@ -267,5 +269,3 @@ class CouponCartDiscountForm(CouponDiscountFormBase, CartDiscountForm):
 class GroupCartDiscountForm(GroupDiscountFormBase, CartDiscountForm):
     settings_iface = IGroupCartDiscountSettings
     action_resource = 'group_cart_discount_form'
-
-

--- a/src/bda/plone/discount/browser/views.py
+++ b/src/bda/plone/discount/browser/views.py
@@ -42,6 +42,9 @@ class ItemDiscountView(DiscountView):
         ('group_cart_item_discount_form',
          _('group_cart_item_discount_form',
            default=u'Group Rules for Cart Items')),
+        ('coupon_cart_item_discount_form',
+         _('coupon_cart_item_discount_form',
+           default=u'Coupon Rules for Cart Items')),
     ]
 
     @property

--- a/src/bda/plone/discount/browser/views.py
+++ b/src/bda/plone/discount/browser/views.py
@@ -74,4 +74,7 @@ class CartDiscountView(DiscountView):
         ('group_cart_discount_form',
          _('group_cart_discount_form',
            default=u'Group Rules for Cart')),
+        ('coupon_cart_discount_form',
+         _('coupon_cart_discount_form',
+           default=u'Coupon Rules for Cart')),
     ]

--- a/src/bda/plone/discount/calculator.py
+++ b/src/bda/plone/discount/calculator.py
@@ -32,6 +32,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 from bda.plone.discount.browser.__init__ import get_existing_coupon_code
 
+
 class RuleLookup(object):
     settings_iface = None
     for_attribute = None

--- a/src/bda/plone/discount/calculator.py
+++ b/src/bda/plone/discount/calculator.py
@@ -30,8 +30,7 @@ from zope.component import queryAdapter
 from zope.component.interfaces import ISite
 from zope.interface import implementer
 from zope.interface import Interface
-from zope.globalrequest import getRequest
-
+from bda.plone.discount.browser.__init__ import get_existing_coupon_code
 
 class RuleLookup(object):
     settings_iface = None
@@ -118,13 +117,7 @@ class RuleAcquierer(object):
         self.user = None
         self.groups = None
 
-        request = getRequest()
-        # Check if new coupon form has been submitted and give it priority over
-        # cookie
-        self.coupon = request.form.get('couponcode')
-        # If no form has been submitted, check for coupon in the cookie
-        if self.coupon is None:
-            self.coupon = request.get('discount_couponcode')
+        self.coupon = get_existing_coupon_code(self)
 
         if self.member:
             self.user = self.member.getId()

--- a/src/bda/plone/discount/calculator.py
+++ b/src/bda/plone/discount/calculator.py
@@ -32,6 +32,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.globalrequest import getRequest
 
+
 class RuleLookup(object):
     settings_iface = None
     for_attribute = None
@@ -79,9 +80,11 @@ class GroupItemRulesLookup(RuleLookup):
     settings_iface = IGroupCartItemDiscountSettings
     for_attribute = FOR_GROUP
 
+
 class CouponItemRulesLookup(RuleLookup):
     settings_iface = ICouponCartItemDiscountSettings
     for_attribute = FOR_COUPON
+
 
 class CartRulesLookup(RuleLookup):
     settings_iface = ICartDiscountSettings
@@ -96,9 +99,11 @@ class GroupCartRulesLookup(RuleLookup):
     settings_iface = IGroupCartDiscountSettings
     for_attribute = FOR_GROUP
 
+
 class CouponCartRulesLookup(RuleLookup):
     settings_iface = ICouponCartDiscountSettings
     for_attribute = FOR_COUPON
+
 
 class RuleAcquierer(object):
     lookup_factory = None
@@ -112,14 +117,15 @@ class RuleAcquierer(object):
         self.member = api.user.get_current()
         self.user = None
         self.groups = None
-        
+
         request = getRequest()
-        # Check if new coupon form has been submitted and give it priority over cookie
+        # Check if new coupon form has been submitted and give it priority over
+        # cookie
         self.coupon = request.form.get('couponcode')
         # If no form has been submitted, check for coupon in the cookie
-        if self.coupon == None:
+        if self.coupon is None:
             self.coupon = request.get('discount_couponcode')
-        
+
         if self.member:
             self.user = self.member.getId()
             try:

--- a/src/bda/plone/discount/calculator.py
+++ b/src/bda/plone/discount/calculator.py
@@ -16,6 +16,7 @@ from bda.plone.discount.interfaces import IGroupCartItemDiscountSettings
 from bda.plone.discount.interfaces import IUserCartDiscountSettings
 from bda.plone.discount.interfaces import IUserCartItemDiscountSettings
 from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
+from bda.plone.discount.interfaces import ICouponCartDiscountSettings
 from bda.plone.discount.interfaces import KIND_ABSOLUTE
 from bda.plone.discount.interfaces import KIND_OFF
 from bda.plone.discount.interfaces import KIND_PERCENT
@@ -95,6 +96,9 @@ class GroupCartRulesLookup(RuleLookup):
     settings_iface = IGroupCartDiscountSettings
     for_attribute = FOR_GROUP
 
+class CouponCartRulesLookup(RuleLookup):
+    settings_iface = ICouponCartDiscountSettings
+    for_attribute = FOR_COUPON
 
 class RuleAcquierer(object):
     lookup_factory = None
@@ -135,10 +139,8 @@ class RuleAcquierer(object):
                 context, self.date, group)
             lookups.append(group_lookup)
         if self.coupon:
-            try:
-                lookups.append(self.coupon_lookup_factory(context, self.date, self.coupon))
-            except:
-                pass
+            lookups.append(self.coupon_lookup_factory(
+                context, self.date, self.coupon))
         lookups.append(self.lookup_factory(context, self.date))
         return lookups
 
@@ -178,6 +180,7 @@ class CartRuleAcquirer(RuleAcquierer):
     lookup_factory = CartRulesLookup
     user_lookup_factory = UserCartRulesLookup
     group_lookup_factory = GroupCartRulesLookup
+    coupon_lookup_factory = CouponCartRulesLookup
 
 
 class DiscountBase(object):

--- a/src/bda/plone/discount/configure.zcml
+++ b/src/bda/plone/discount/configure.zcml
@@ -48,6 +48,15 @@
   <adapter factory=".settings.GroupCartItemDiscountSettings"
            for="Products.CMFPlone.interfaces.IPloneSiteRoot"
            provides=".interfaces.IGroupCartItemDiscountSettings" />
+  
+  <!-- coupon cart item discount settings -->
+  <adapter factory=".settings.CouponCartItemDiscountSettings"
+           for=".interfaces.IDiscountSettingsEnabled"
+           provides=".interfaces.ICouponCartItemDiscountSettings" />
+
+  <adapter factory=".settings.CouponCartItemDiscountSettings"
+           for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+           provides=".interfaces.ICouponCartItemDiscountSettings" />
 
   <!-- cart discount settings -->
   <adapter factory=".settings.CartDiscountSettings"

--- a/src/bda/plone/discount/configure.zcml
+++ b/src/bda/plone/discount/configure.zcml
@@ -70,6 +70,10 @@
   <adapter factory=".settings.GroupCartDiscountSettings"
            provides=".interfaces.IGroupCartDiscountSettings" />
 
+  <!-- coupon cart discount settings -->
+  <adapter factory=".settings.CouponCartDiscountSettings"
+           provides=".interfaces.ICouponCartDiscountSettings" />
+
   <!-- cart item discount calculators -->
   <adapter factory=".calculator.CartItemDiscount"
            provides="bda.plone.cart.interfaces.ICartItemDiscount" />

--- a/src/bda/plone/discount/interfaces.py
+++ b/src/bda/plone/discount/interfaces.py
@@ -9,6 +9,7 @@ CATEGORY_CART_ITEM = 'cart_item'
 CATEGORY_CART = 'cart'
 FOR_USER = 'user'
 FOR_GROUP = 'group'
+FOR_COUPON = 'coupon'
 KIND_PERCENT = 'percent'
 KIND_OFF = 'off'
 KIND_ABSOLUTE = 'absolute'
@@ -46,6 +47,10 @@ class IUserCartItemDiscountSettings(ICartItemDiscountSettings):
 
 class IGroupCartItemDiscountSettings(ICartItemDiscountSettings):
     """Interface for cart item group discount settings.
+    """
+
+class ICouponCartItemDiscountSettings(ICartItemDiscountSettings):
+    """Interface for cart item coupon discount settings.
     """
 
 

--- a/src/bda/plone/discount/interfaces.py
+++ b/src/bda/plone/discount/interfaces.py
@@ -67,3 +67,9 @@ class IUserCartDiscountSettings(ICartDiscountSettings):
 class IGroupCartDiscountSettings(ICartDiscountSettings):
     """Interface for cart group discount settings.
     """
+
+
+class ICouponCartDiscountSettings(ICartDiscountSettings):
+    """Interface for cart coupon discount settings.
+    """
+    

--- a/src/bda/plone/discount/interfaces.py
+++ b/src/bda/plone/discount/interfaces.py
@@ -49,6 +49,7 @@ class IGroupCartItemDiscountSettings(ICartItemDiscountSettings):
     """Interface for cart item group discount settings.
     """
 
+
 class ICouponCartItemDiscountSettings(ICartItemDiscountSettings):
     """Interface for cart item coupon discount settings.
     """
@@ -72,4 +73,3 @@ class IGroupCartDiscountSettings(ICartDiscountSettings):
 class ICouponCartDiscountSettings(ICartDiscountSettings):
     """Interface for cart coupon discount settings.
     """
-    

--- a/src/bda/plone/discount/settings.py
+++ b/src/bda/plone/discount/settings.py
@@ -13,6 +13,7 @@ from bda.plone.discount.interfaces import IGroupCartDiscountSettings
 from bda.plone.discount.interfaces import IGroupCartItemDiscountSettings
 from bda.plone.discount.interfaces import IUserCartDiscountSettings
 from bda.plone.discount.interfaces import IUserCartItemDiscountSettings
+from bda.plone.discount.interfaces import ICouponCartDiscountSettings
 from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
 from datetime import datetime
 from plone.uuid.interfaces import IUUID
@@ -60,6 +61,7 @@ class DiscountRulesCatalogFactory(object):
         # coupon this rule applies
         coupon_indexer = NodeAttributeIndexer('coupon')
         catalog[u'coupon'] = CatalogFieldIndex(coupon_indexer)
+
         return catalog
 
 
@@ -119,7 +121,7 @@ class PersistendDiscountSettings(object):
                 msg = u'``user`` and ``group`` and ``coupon`` keywords must not be given ' +\
                       u'if scope is general'
                 raise ValueError(msg)
-            query = query & Eq('user', '') & Eq('group', '')
+            query = query & Eq('user', '') & Eq('group', '') & Eq('coupon', '')
         return self.rules_soup.query(query,
                                      sort_index='valid_from',
                                      reverse=True)
@@ -180,8 +182,9 @@ class UserCartItemDiscountSettings(CartItemDiscountSettings):
 class GroupCartItemDiscountSettings(CartItemDiscountSettings):
     for_attribute = FOR_GROUP
 
+
 @implementer(ICouponCartItemDiscountSettings)
-class CouponCartItemDiscountSettings(PersistendDiscountSettings):
+class CouponCartItemDiscountSettings(CartItemDiscountSettings):
     for_attribute = FOR_COUPON
 
 
@@ -197,7 +200,14 @@ class UserCartDiscountSettings(CartDiscountSettings):
     for_attribute = FOR_USER
 
 
+@implementer(ICouponCartDiscountSettings)
+@adapter(IPloneSiteRoot)
+class CouponCartDiscountSettings(CartDiscountSettings):
+    for_attribute = FOR_COUPON
+
+
 @implementer(IGroupCartDiscountSettings)
 @adapter(IPloneSiteRoot)
 class GroupCartDiscountSettings(CartDiscountSettings):
     for_attribute = FOR_GROUP
+

--- a/src/bda/plone/discount/settings.py
+++ b/src/bda/plone/discount/settings.py
@@ -210,4 +210,3 @@ class CouponCartDiscountSettings(CartDiscountSettings):
 @adapter(IPloneSiteRoot)
 class GroupCartDiscountSettings(CartDiscountSettings):
     for_attribute = FOR_GROUP
-

--- a/src/bda/plone/discount/tests/calculator.rst
+++ b/src/bda/plone/discount/tests/calculator.rst
@@ -12,9 +12,11 @@ Import settings related interfaces::
     >>> from bda.plone.discount.interfaces import ICartItemDiscountSettings
     >>> from bda.plone.discount.interfaces import IUserCartItemDiscountSettings
     >>> from bda.plone.discount.interfaces import IGroupCartItemDiscountSettings
+    >>> from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
     >>> from bda.plone.discount.interfaces import ICartDiscountSettings
     >>> from bda.plone.discount.interfaces import IUserCartDiscountSettings
     >>> from bda.plone.discount.interfaces import IGroupCartDiscountSettings
+    >>> from bda.plone.discount.interfaces import ICouponCartDiscountSettings
 
 
 RuleLookup
@@ -25,9 +27,11 @@ Import rules lookup implementations::
     >>> from bda.plone.discount.calculator import ItemRulesLookup
     >>> from bda.plone.discount.calculator import UserItemRulesLookup
     >>> from bda.plone.discount.calculator import GroupItemRulesLookup
+    >>> from bda.plone.discount.calculator import CouponItemRulesLookup
     >>> from bda.plone.discount.calculator import CartRulesLookup
     >>> from bda.plone.discount.calculator import UserCartRulesLookup
     >>> from bda.plone.discount.calculator import GroupCartRulesLookup
+    >>> from bda.plone.discount.calculator import CouponCartRulesLookup
 
 Test lookup objects::
 
@@ -59,6 +63,15 @@ Test lookup objects::
 
     >>> GroupItemRulesLookup(plone, date, for_value='grp2').lookup()
 
+    >>> settings = ICouponCartItemDiscountSettings(plone)
+    >>> settings.add_rule(
+    ...     plone, 0, 'percent', False, 15.0, UNSET, UNSET, UNSET, group='cp1')
+
+    >>> CouponItemRulesLookup(plone, date, for_value='cp1').lookup()
+    <Record object 'None' at ...>
+
+    >>> CouponItemRulesLookup(plone, date, for_value='cp2').lookup()
+
     >>> settings = ICartDiscountSettings(plone)
     >>> settings.add_rule(
     ...     plone, 0, 'percent', False, 20.0, UNSET, UNSET, UNSET)
@@ -82,6 +95,15 @@ Test lookup objects::
     >>> GroupCartRulesLookup(plone, date, for_value='grp1').lookup()
 
     >>> GroupCartRulesLookup(plone, date, for_value='grp2').lookup()
+    <Record object 'None' at ...>
+
+    >>> settings = ICouponCartDiscountSettings(plone)
+    >>> settings.add_rule(
+    ...     plone, 0, 'percent', False, 30.0, UNSET, UNSET, UNSET, group='cp2')
+
+    >>> CouponCartRulesLookup(plone, date, for_value='cp1').lookup()
+
+    >>> CouponCartRulesLookup(plone, date, for_value='cp2').lookup()
     <Record object 'None' at ...>
 
 

--- a/src/bda/plone/discount/tests/settings.rst
+++ b/src/bda/plone/discount/tests/settings.rst
@@ -23,6 +23,7 @@ Debug print helper::
     ...     print 'valid_to: ' + str(rule.attrs['valid_to'])
     ...     print 'user: ' + rule.attrs['user']
     ...     print 'group: ' + rule.attrs['group']
+    ...     print 'coupon: ' + rule.attrs['coupon']
 
 
 ICartItemDiscountSettings
@@ -68,6 +69,7 @@ Look at rule data::
     valid_to: 2014-04-01 00:00:00
     user: 
     group: 
+    coupon: 
 
 Rules are returned sorted by valid_from, most recent first::
 
@@ -172,7 +174,7 @@ IUserCartItemDiscountSettings
     valid_to: 2100-01-01 00:00:00
     user: max
     group: 
-
+    coupon: 
 
 IGroupCartItemDiscountSettings
 ------------------------------
@@ -206,7 +208,41 @@ IGroupCartItemDiscountSettings
     valid_to: 2100-01-01 00:00:00
     user: 
     group: retailer
+    coupon: 
 
+ICouponCartItemDiscountSettings
+------------------------------
+
+::
+
+    >>> from bda.plone.discount.interfaces import ICouponCartItemDiscountSettings
+    >>> settings = ICouponCartItemDiscountSettings(plone)
+    >>> settings
+    <bda.plone.discount.settings.CouponCartItemDiscountSettings object at ...>
+
+    >>> settings.add_rule(
+    ...     plone, 0, 'percent', False, 10.0,
+    ...     UNSET, UNSET, UNSET, coupon='couponcode')
+
+    >>> rules = [_ for _ in settings.rules(plone)]
+    >>> len(rules)
+    1
+
+    >>> print_rule(rules[0])
+    index: 0
+    category: cart_item
+    context_uid: 77c4390d-1179-44ba-9d57-46d23ac292c6
+    creator: test_user_1_
+    created: ...
+    kind: percent
+    block: False
+    value: 10.0
+    threshold: 
+    valid_from: 2000-01-01 00:00:00
+    valid_to: 2100-01-01 00:00:00
+    user: 
+    group: 
+    coupon: couponcode
 
 ICartDiscountSettings
 ---------------------
@@ -273,6 +309,7 @@ IUserCartDiscountSettings
     valid_to: 2100-01-01 00:00:00
     user: sepp
     group: 
+    coupon:
 
 
 IGroupCartDiscountSettings
@@ -307,7 +344,41 @@ IGroupCartDiscountSettings
     valid_to: 2100-01-01 00:00:00
     user: 
     group: master_dealer
+    coupon:
 
+ICouponCartDiscountSettings
+--------------------------
+
+::
+
+    >>> from bda.plone.discount.interfaces import ICouponCartDiscountSettings
+    >>> settings = ICouponCartDiscountSettings(plone)
+    >>> settings
+    <bda.plone.discount.settings.CouponCartDiscountSettings object at ...>
+
+    >>> settings.add_rule(
+    ...     plone, 0, 'percent', False, 10.0,
+    ...     UNSET, UNSET, UNSET, coupon='couponcode')
+
+    >>> rules = [_ for _ in settings.rules(plone)]
+    >>> len(rules)
+    1
+
+    >>> print_rule(rules[0])
+    index: 0
+    category: cart
+    context_uid: 77c4390d-1179-44ba-9d57-46d23ac292c6
+    creator: test_user_1_
+    created: ...
+    kind: percent
+    block: False
+    value: 10.0
+    threshold: 
+    valid_from: 2000-01-01 00:00:00
+    valid_to: 2100-01-01 00:00:00
+    user: 
+    group: 
+    coupon: couponcode
 
 IDiscountSettingsEnabled
 ------------------------
@@ -339,6 +410,9 @@ IDiscountSettingsEnabled
 
     >>> IGroupCartItemDiscountSettings(folder)
     <bda.plone.discount.settings.GroupCartItemDiscountSettings object at ...>
+
+    >>> ICouponCartItemDiscountSettings(folder)
+    <bda.plone.discount.settings.CouponCartItemDiscountSettings object at ...>
 
     >>> ICartDiscountSettings(folder)
     Traceback (most recent call last):


### PR DESCRIPTION
This PR implements a basic coupon code functionality to bda.plone.discount. The coupon codes are managed through an existing item/cart discount settings page, where a new table is added for coupon management. In addition, a viewlet is added to enable users to input a coupon code, which is then stored in a cookie. The discount core reads the information form a cookie and finds an appropriate discount rule to be applied.

Only manual testing has been performed, no automatic tests yet.